### PR TITLE
Compatibility with AS 0.6.x+ Gradle Plugins

### DIFF
--- a/GradlePlugin/buildSrc/src/main/groovy/com/evilduck/aptlibs/AptlibsPlugin.groovy
+++ b/GradlePlugin/buildSrc/src/main/groovy/com/evilduck/aptlibs/AptlibsPlugin.groovy
@@ -65,7 +65,7 @@ public class AptlibsPlugin implements Plugin<Project> {
 
     def modifyJavaCompilerArguments() {
         project.android.applicationVariants.all { variant ->
-            def aptOutput = project.file("$project.buildDir/source/$aptlibsExt.aptDir/$variant.dirName")
+            def aptOutput = project.file("$project.buildDir/generated/source/$aptlibsExt.aptDir/$variant.dirName")
             variant.addJavaSourceFoldersToModel(aptOutput)
 
             variant.javaCompile.doFirst {


### PR DESCRIPTION
Since Beta release of Android Studio the build/ tree has changed a bit (technically since AS 0.6.x release, which includes all relevant changes to gradle plugins). This patch places the generated files into the correct directory.
