### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,18 @@
-#####Changelog
-######version 1.10.3
+##### Changelog
+###### version 1.10.3
 * add "extra" attribute to @Column 
 
-######version 1.10.2
+###### version 1.10.2
 * add TagLogger.java
 * add methods to UriBuilder in Provider class
 * improve plugin
 
-######version 1.10.0
+###### version 1.10.0
 * support plugins
 * custom mime type for @Uri
 * reformat code: use whitespaces instead tab
 
-######version 1.9.0
+###### version 1.9.0
 * bulkinsert: support 2 modes: replace and insert
 * insert: support all conflict resolution modes
 * add 2 new arguments to @Provider - default mode for bulkinsert and insert

--- a/README.md
+++ b/README.md
@@ -3,24 +3,24 @@ Android-AnnotatedSQL
 
 Android library for auto generating SQL schema and Content Provider by annotations. You will get a full-featured content provider in 5 minutes :)
 
-#####Wiki:
+##### Wiki:
 All information was moved to the [Wiki][5]
 
-#####Maven repo:
+##### Maven repo:
 ```groovy
 com.github.hamsterksu:android-annotatedsql-api:1.10.+
 com.github.hamsterksu:android-annotatedsql-processor:1.10.+
 ```
 
-#####Changelog
+##### Changelog
 Current version is 1.10.3. You can find changlog [here](CHANGELOG.md)
 
-#####Available plugins
+##### Available plugins
 * Projections - [annotatedsql-projection-plugin][1]
 * Android-AnnotatedSQL-WrapperPlugin - [Android-AnnotatedSQL-WrapperPlugin][4]
 
 ***
-#####How to start?
+##### How to start?
 All necessary information in [Wiki][5].
 
 There are: 
@@ -28,7 +28,7 @@ There are:
 * Define SQL Schema
 * Define Content Provider
 
-#####Tools and links
+##### Tools and links
 * gradle plugin to connect apt - [android-aptlibs-gradle-plugin][2]
 * demo application source - [annotatedsql_demo][3]
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
